### PR TITLE
Handle sensor_id via roslaunch arg/param and set_sensor_id service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ roslaunch ars_40X ars_40X.launch visualize:=true obstacle_array:=true
 - **sensor_id** *(default:0)* : The sensor_id of the radar to use (0-7), determines the message IDs on the CAN bus (see radar documentation)
 - **publish_radardetection** *(default:"true")* : Launches a converter, which converts from object lists to ROS radar detection messages
 
-<arg name="publish_radardetection" default="true"/>
-  <arg name="frame_id" default="radar" />
-  <arg name="sensor_id" default="0" />
-
 #### Publications
 
 |Message|Type|Description|Message Box|

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ roslaunch ars_40X ars_40X.launch visualize:=true obstacle_array:=true
 
 - **visualize** *(default:"true")* : Launches RViz to display the clusters/obstacles as markers.
 - **obstacle_array** *(default:"false")* : Launches ars_40X_obstacle_array node which publishes obstacles as geometry_msgs/Polygon
+- **frame_id** *(default:"radar")* : Sets the `frame_id` for published markers
+- **sensor_id** *(default:0)* : The sensor_id of the radar to use (0-7), determines the message IDs on the CAN bus (see radar documentation)
+- **publish_radardetection** *(default:"true")* : Launches a converter, which converts from object lists to ROS radar detection messages
+
+<arg name="publish_radardetection" default="true"/>
+  <arg name="frame_id" default="radar" />
+  <arg name="sensor_id" default="0" />
 
 #### Publications
 

--- a/include/ars_40X/ars_40X_can.hpp
+++ b/include/ars_40X/ars_40X_can.hpp
@@ -46,7 +46,9 @@ class ARS_40X_CAN {
  public:
   ARS_40X_CAN();
 
-  ARS_40X_CAN(std::string port);
+  ARS_40X_CAN(uint8_t sensor_id);
+
+  ARS_40X_CAN(std::string port, uint8_t sensor_id);
 
   ~ARS_40X_CAN();
 
@@ -92,6 +94,8 @@ class ARS_40X_CAN {
 
   virtual void send_radar_state() {};
 
+  void update_sensor_id(uint8_t sensor_id);
+
  private:
   socket_can::SocketCAN can_;
 
@@ -116,6 +120,8 @@ class ARS_40X_CAN {
   radar_state::RadarState radar_state_;
 
   radar_cfg::RadarCfg radar_cfg_;
+
+  uint8_t sensor_id_offset_;
 };
 }
 

--- a/launch/ars_40X.launch
+++ b/launch/ars_40X.launch
@@ -2,9 +2,12 @@
   <arg name="visualize" default="true"/>
   <arg name="obstacle_array" default="false"/>
   <arg name="publish_radardetection" default="true"/>
+  <arg name="frame_id" default="radar" />
+  <arg name="sensor_id" default="0" />
 
   <node pkg="ars_40X" type="ars_40X_ros" name="ars_40X_ros" output="screen">
-    <!--<param name="frame_id" value="radar_link"/>-->
+    <param name="frame_id" value="$(arg frame_id)"/>
+    <param name="sensor_id" value="$(arg sensor_id)"/>
   </node>
   
   <node pkg="ars_40X" type="convert_to_radardetectionlist.py" name="object_list_converter" output="screen" if="$(arg publish_radardetection)" />

--- a/launch/ars_40X.launch
+++ b/launch/ars_40X.launch
@@ -5,20 +5,20 @@
   <arg name="frame_id" default="radar" />
   <arg name="sensor_id" default="0" />
 
-  <node pkg="ars_40X" type="ars_40X_ros" name="ars_40X_ros" output="screen">
+  <node pkg="ars_40X" type="ars_40X_ros" name="$(anon ars_40X_ros)" output="screen">
     <param name="frame_id" value="$(arg frame_id)"/>
     <param name="sensor_id" value="$(arg sensor_id)"/>
   </node>
   
-  <node pkg="ars_40X" type="convert_to_radardetectionlist.py" name="object_list_converter" output="screen" if="$(arg publish_radardetection)" />
+  <node pkg="ars_40X" type="convert_to_radardetectionlist.py" name="$(anon object_list_converter)" output="screen" if="$(arg publish_radardetection)" />
 
   <group if="$(arg visualize)">
-    <node pkg="ars_40X" type="ars_40X_rviz" name="ars_40X_rviz"/>
-    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find ars_40X)/rviz_cfg/ars_40X.rviz"/>
+    <node pkg="ars_40X" type="ars_40X_rviz" name="$(anon ars_40X_rviz)"/>
+    <node pkg="rviz" type="rviz" name="$(anon rviz)" args="-d $(find ars_40X)/rviz_cfg/ars_40X.rviz"/>
   </group>
 
   <group if="$(arg obstacle_array)">
-    <node pkg="ars_40X" type="ars_40X_obstacle_array" name="ars_40X_obstacle_array">
+    <node pkg="ars_40X" type="ars_40X_obstacle_array" name="$(anon ars_40X_obstacle_array)">
       <!--<remap from="obstacles" to="/move_base/TebLocalPlannerROS/obstacles"/>-->
     </node>
   </group>

--- a/launch/ars_40X.launch
+++ b/launch/ars_40X.launch
@@ -1,10 +1,13 @@
 <launch>
   <arg name="visualize" default="true"/>
   <arg name="obstacle_array" default="false"/>
+  <arg name="publish_radardetection" default="true"/>
 
   <node pkg="ars_40X" type="ars_40X_ros" name="ars_40X_ros" output="screen">
     <!--<param name="frame_id" value="radar_link"/>-->
   </node>
+  
+  <node pkg="ars_40X" type="convert_to_radardetectionlist.py" name="object_list_converter" output="screen" if="$(arg publish_radardetection)" />
 
   <group if="$(arg visualize)">
     <node pkg="ars_40X" type="ars_40X_rviz" name="ars_40X_rviz"/>

--- a/scripts/convert_to_radardetectionlist.py
+++ b/scripts/convert_to_radardetectionlist.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import rospy
+from ars_40X.msg import Object, ObjectList, Cluster, ClusterList
+from radar_msgs.msg import RadarDetection, RadarDetectionArray
+
+def object_list_callback(object_list, detection_array_publisher):
+    radar_detection_array = RadarDetectionArray()
+    radar_detection_array.header = object_list.header
+    for obj in object_list.objects:
+        radar_detection = RadarDetection()
+        radar_detection.detection_id = obj.id
+        radar_detection.position = obj.position.pose.position
+        radar_detection.velocity = obj.relative_velocity.twist.linear
+        radar_detection.amplitude = obj.rcs
+        radar_detection_array.detections.append(radar_detection)
+    detection_array_publisher.publish(radar_detection_array)
+
+
+if __name__ == '__main__':
+    rospy.init_node('object_list_converter')
+    publisher = rospy.Publisher("/radar_converter/detections", RadarDetectionArray, queue_size=10)
+    callback_closure = lambda object_list: object_list_callback(object_list, publisher)
+    rospy.Subscriber('/ars_40X/objects', ObjectList, callback_closure)
+    rospy.spin()

--- a/scripts/convert_to_radardetectionlist.py
+++ b/scripts/convert_to_radardetectionlist.py
@@ -4,22 +4,34 @@ import rospy
 from ars_40X.msg import Object, ObjectList, Cluster, ClusterList
 from radar_msgs.msg import RadarDetection, RadarDetectionArray
 
+
+def convert_to_detection(obj):
+    radar_detection = RadarDetection()
+    radar_detection.detection_id = obj.id
+    radar_detection.position = obj.position.pose.position
+    radar_detection.velocity = obj.relative_velocity.twist.linear
+    radar_detection.amplitude = obj.rcs
+    return radar_detection
+
 def object_list_callback(object_list, detection_array_publisher):
     radar_detection_array = RadarDetectionArray()
     radar_detection_array.header = object_list.header
-    for obj in object_list.objects:
-        radar_detection = RadarDetection()
-        radar_detection.detection_id = obj.id
-        radar_detection.position = obj.position.pose.position
-        radar_detection.velocity = obj.relative_velocity.twist.linear
-        radar_detection.amplitude = obj.rcs
-        radar_detection_array.detections.append(radar_detection)
+    try:
+        objects = getattr(object_list, 'objects')
+    except AttributeError:
+        objects = getattr(object_list, 'clusters')
+    radar_detection_array.detections = [convert_to_detection(obj) for obj in objects]
     detection_array_publisher.publish(radar_detection_array)
 
 
 if __name__ == '__main__':
     rospy.init_node('object_list_converter')
-    publisher = rospy.Publisher("/radar_converter/detections", RadarDetectionArray, queue_size=10)
-    callback_closure = lambda object_list: object_list_callback(object_list, publisher)
-    rospy.Subscriber('/ars_40X/objects', ObjectList, callback_closure)
+    publisher = rospy.Publisher("/radar_converter/detections123", RadarDetectionArray, queue_size=10)
+    
+    object_list_callback_closure = lambda object_list: object_list_callback(object_list, publisher)
+    rospy.Subscriber('/ars_40X/objects', ObjectList, object_list_callback_closure)
+    
+    cluster_list_callback_closure = lambda cluster_list: object_list_callback(cluster_list, publisher)
+    rospy.Subscriber('/ars_40X/clusters', ClusterList, cluster_list_callback_closure)
+
     rospy.spin()

--- a/src/ros/ars_40X_ros.cpp
+++ b/src/ros/ars_40X_ros.cpp
@@ -14,7 +14,10 @@ ARS_40X_ROS::ARS_40X_ROS(ros::NodeHandle &nh) :
     radar_state_ros_(nh_, this) {
   ros::NodeHandle private_nh("~");
   std::string frame_id;
+  int sensor_id;
   private_nh.param<std::string>("frame_id", frame_id, std::string("radar"));
+  private_nh.param<int>("sensor_id", sensor_id, 0);
+  update_sensor_id(sensor_id);
   cluster_list_ros_.set_frame_id(frame_id);
   object_list_ros_.set_frame_id(frame_id);
 }

--- a/src/ros/radar_cfg_ros.cpp
+++ b/src/ros/radar_cfg_ros.cpp
@@ -49,6 +49,7 @@ bool RadarCfgROS::set_sensor_id(
     return false;
   }
   ars_40X_can_->send_radar_data(can_messages::RadarCfg);
+  ars_40X_can_->update_sensor_id(req.sensor_id);
   return true;
 }
 


### PR DESCRIPTION
I wrote a patch to make the radar use a configurable sensor_id, which can be set via roslaunch arg.

This also makes it possible to use the radar without problems after calling the `set_sensor_id` service without restarting the node as it updates the current sensor id and starts looking for the correct message IDs after a change. After a restart of the node, the roslaunch arg/param has to be set to the new sensor_id, of course.

Also included is a converter from object lists to ROS radardetection messages. Haven't yet added the function to convert from cluster lists but might do.